### PR TITLE
DO-1499: Fixed workdir issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY entrypoint.sh ./
 COPY pipe ./pipe
 RUN chmod a+x ./pipe/*.ts entrypoint.sh
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/pipe/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ Each application should also have a `project.json` file defining an `nx` target 
 ## Development
 
 To build the image locally: \
-`docker build --build-arg="NODE_TAG=18-alpine" -t aligent/nx-pipe .`
+`docker build --build-arg="NODE_TAG=18-alpine" -t aligent/nx-pipe:18-alpine .`
 
 To run the container locally and mount current local directory to the /app/work folder:
 
 ```bash
-docker run -it -v $(pwd):/app/work --memory=4g --memory-swap=4g --memory-swappiness=0 --cpus=4 --entrypoint=/bin/sh \
+docker run -it --memory=4g --memory-swap=4g --memory-swappiness=0 --cpus=4 --entrypoint=/bin/sh \
+  -v $(pwd):/app/work --workdir=/app/work \
   -e BITBUCKET_CLONE_DIR=/app/work \
   -e PROFILE=bitbucket-deployer \
   -e STAGE=stg \
@@ -88,7 +89,7 @@ docker run -it -v $(pwd):/app/work --memory=4g --memory-swap=4g --memory-swappin
   -e UPLOAD_BADGE=false \
   -e APP_USERNAME=test-app-username \
   -e APP_PASSWORD=test-app-password \
-  aligent/nx-pipe:latest
+  aligent/nx-pipe:18-alpine
 ```
 
 ## See also

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 #set -x
 
+cd /pipe
 npx ts-node pipe/entrypoint.ts


### PR DESCRIPTION
This PR fix the issue:

`docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./entrypoint.sh": stat ./entrypoint.sh: no such file or directory: unknown.`

The problem is that Bitbucket pass in `--workdir=$(pwd)` flag while starting docker container. Therefore, we need to:

1. set the ENTRYPOINT to the absolute path of the file: `/pipe/entrypoint.sh`
2. cd to `/pipe` folder before running `npx ts-node pipe/entrypoint.ts`.