### PR TITLE
DO-1499: terminate with exit code on error

### DIFF
--- a/pipe/entrypoint.ts
+++ b/pipe/entrypoint.ts
@@ -4,27 +4,39 @@ import { findServerlessYaml } from "./findServerlessYaml";
 import { injectCfnRole } from "./injectCfnRole";
 import { uploadDeploymentBadge } from "./uploadDeploymentBadge";
 
-findServerlessYaml(`${process.env.BITBUCKET_CLONE_DIR}/services`)
-  .then((files) =>
-    Promise.all(files.map((file) => injectCfnRole(file, env.cfnRole)))
-  )
-  .then(() => {
+async function main() {
+  let deploymentStatus = false;
+
+  try {
     if (!env.awsAccessKeyId || !env.awsSecretAccessKey) {
       throw new Error("AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY not set");
     }
 
-    runCLICommand([
+    const serverlessFiles = await findServerlessYaml(
+      `${process.env.BITBUCKET_CLONE_DIR}/services`
+    );
+    await Promise.all(
+      serverlessFiles.map((file) => injectCfnRole(file, env.cfnRole))
+    );
+
+    await runCLICommand([
       "npm ci",
       `npx serverless config credentials --provider aws --profile ${env.profile} --key ${env.awsAccessKeyId} --secret ${env.awsSecretAccessKey}`,
       `npx nx run-many -t deploy --stage ${env.stage} --aws-profile ${env.profile}`,
     ]);
-  })
-  .then(() => uploadDeploymentBadge(true))
-  .catch((error) => {
-    console.error(error);
-    uploadDeploymentBadge(false);
-  });
 
-process.on("unhandledRejection", (error) => {
-  console.error("Unhandled rejection", error);
-});
+    deploymentStatus = true;
+  } catch (error) {
+    console.error(
+      "Deployment failed! Please check the logs for more details.Error:",
+      error as Error
+    );
+    deploymentStatus = false;
+  } finally {
+    const statusCode = await uploadDeploymentBadge(deploymentStatus);
+    process.exit(statusCode);
+  }
+}
+
+// Execute the main function
+main();

--- a/pipe/injectCfnRole.ts
+++ b/pipe/injectCfnRole.ts
@@ -2,6 +2,7 @@ import type { AWS } from "@serverless/typescript";
 import { readFile, writeFile } from "fs/promises";
 import { dump, load } from "js-yaml";
 import { CLOUDFORMATION_SCHEMA } from "js-yaml-cloudformation-schema";
+import { env } from "./env";
 
 export async function injectCfnRole(
   serverlessYamlPath: string,
@@ -13,8 +14,7 @@ export async function injectCfnRole(
     const yaml = await readFile(serverlessYamlPath, "utf8");
     const serverless = load(yaml, { schema: CLOUDFORMATION_SCHEMA }) as AWS;
 
-    // TODO: Remove this development log
-    console.log(JSON.stringify(serverless, null, 2));
+    if (env.debug) console.log(JSON.stringify(serverless, null, 2));
 
     // Ensure iam exists in the provider block
     if (!("iam" in serverless.provider)) {


### PR DESCRIPTION
I do some refactor to make sure the execution flow works as expected and exit with correct status code. Hope it will makes the pipeline fails if deployment fails (exit code = 1). It's hard to test locally though as we runs the script by `ts-node`. Maybe it's better if we bundle it to `js` file instead of running by `ts-node`.

Toggle: DO-1499: Code Review