### PR TITLE
DO-1499: enable nodejs corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 ARG NODE_TAG
 FROM node:${NODE_TAG}
 
-RUN mkdir /pipe
-WORKDIR /pipe
-
+RUN corepack enable
 RUN apk add wget 
 RUN wget -P / https://bitbucket.org/bitbucketpipelines/bitbucket-pipes-toolkit-bash/raw/0.4.0/common.sh
+
+RUN mkdir /pipe
+WORKDIR /pipe
 
 COPY tsconfig.json ./
 COPY pack*.json ./


### PR DESCRIPTION
This PR enable `corepack` so our pipeline can support multiple package managers. Below is the list with version that come with Node 18 alpine

- NPM (v9.8.1)
- PNPM (V8.10.2)
- YARN (1.22.19)