### PR TITLE
feat DO-1593: add support for non-mono repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.release.target_commitish }}
-    - run: docker build --build-arg NODE_TAG=20-alpine .
+    - run: docker build --build-arg NODE_TAG=20 .
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_TAG
-FROM node:${NODE_TAG}
+FROM node:${NODE_TAG}-alpine
 
 RUN mkdir /pipe
 WORKDIR /pipe

--- a/pipe/env.ts
+++ b/pipe/env.ts
@@ -2,6 +2,7 @@ interface Env {
   debug: boolean;
   stage: string;
   profile: string;
+  cmd: string;
   awsAccessKeyId?: string;
   awsSecretAccessKey?: string;
   cfnRole?: string;
@@ -12,12 +13,14 @@ interface Env {
   bitbucketBranch?: string;
   bitbucketRepoSlug?: string;
   bitbucketWorkspace?: string;
+  servicesPath?: string;
 }
 
 export const env: Env = {
   debug: process.env.DEBUG === "true",
   stage: process.env.STAGE || "stg",
   profile: process.env.PROFILE || "bitbucket-deployer",
+  cmd: process.env.cmd || "deploy",
   awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
   awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   cfnRole: process.env.CFN_ROLE,
@@ -28,4 +31,5 @@ export const env: Env = {
   bitbucketBranch: process.env.BITBUCKET_BRANCH,
   bitbucketRepoSlug: process.env.BITBUCKET_REPO_SLUG,
   bitbucketWorkspace: process.env.BITBUCKET_WORKSPACE,
+  servicesPath: process.env.servicesPath || "/services",
 };

--- a/pipe/findNodeModules.ts
+++ b/pipe/findNodeModules.ts
@@ -1,0 +1,16 @@
+import * as fs from "fs";
+
+export async function nodeModulesDirectoryExist(
+  directoryPath: string
+): Promise<boolean> {
+  return fs.promises
+    .access(`${directoryPath}/node_modules`, fs.constants.F_OK)
+    .then(() => true)
+    .catch((error) => {
+      if (error.code === "ENOENT") {
+        return false;
+      } else {
+        throw error;
+      }
+    });
+}

--- a/pipe/findServerlessYaml.ts
+++ b/pipe/findServerlessYaml.ts
@@ -6,7 +6,7 @@ export async function findServerlessYaml(basePath: string) {
 
   console.log(`Fetching serverless configuration with pattern ${globPattern}`);
 
-  const files = await glob(globPattern, {});
+  const files = await glob(globPattern, { ignore: ["**/node_modules/**"] });
 
   for (const file of files) {
     console.log("Found serverless.yml at: ", file);


### PR DESCRIPTION
Adds support for standard serverless projects. The idea behind this is to remove the old deploy pipe repo and use this for both nx repos and standard serverless repos. 

TODO: allow custom run command