### PR TITLE
MI-206: Have CI_DEBUG affect package manager install command(s)

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -55,7 +55,7 @@ async function main() {
             bitbucketCloneDir
         );
         if (!isNodeModulesExists) {
-            const installCmd = getInstallCommand(packageManager, debug);
+            const installCmd = getInstallCommand(packageManager);
             commands.unshift(installCmd);
         }
 

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -55,7 +55,7 @@ async function main() {
             bitbucketCloneDir
         );
         if (!isNodeModulesExists) {
-            const installCmd = getInstallCommand(packageManager);
+            const installCmd = getInstallCommand(packageManager, debug);
             commands.unshift(installCmd);
         }
 

--- a/lib/packageManagers.ts
+++ b/lib/packageManagers.ts
@@ -1,6 +1,18 @@
 import { existsSync } from 'fs';
 
-type PackageManager = 'npm' | 'pnpm' | 'yarn';
+const supportedPackageManagers = ['npm', 'pnpm', 'yarn'] as const;
+type PackageManager = (typeof supportedPackageManagers)[number];
+
+const installCommands: Record<PackageManager, string> = {
+    npm: 'npm ci',
+    pnpm: 'pnpm install --frozen-lockfile',
+    yarn: 'yarn install --frozen-lockfile',
+};
+const debugFlags: Record<PackageManager, string> = {
+    npm: '--verbose',
+    pnpm: '--verbose',
+    yarn: '--verbose',
+};
 
 export function detectPackageManager(directoryPath: string): PackageManager {
     if (existsSync(`${directoryPath}/yarn.lock`)) {
@@ -14,13 +26,18 @@ export function detectPackageManager(directoryPath: string): PackageManager {
     return `npm`;
 }
 
-export function getInstallCommand(packageManager: PackageManager) {
-    switch (packageManager) {
-        case 'npm':
-            return 'npm ci';
-        case 'pnpm':
-            return 'pnpm install --frozen-lockfile';
-        case 'yarn':
-            return 'yarn install --frozen-lockfile';
+export function getInstallCommand(
+    packageManager: PackageManager,
+    debug: boolean = false,
+): string {
+    const installCommand = installCommands[packageManager];
+    if (!installCommand) {
+        const packageManagers = supportedPackageManagers.join(', ');
+        throw new Error(
+            `Unsupported package manager: "${packageManager}". Options are: ${packageManagers}`,
+        );
     }
+
+    const debugFlag = debug ? ` ${debugFlags[packageManager]}` : '';
+    return `${installCommand}${debugFlag}`;
 }

--- a/lib/packageManagers.ts
+++ b/lib/packageManagers.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs';
+import { env } from './env';
 
 const supportedPackageManagers = ['npm', 'pnpm', 'yarn'] as const;
 type PackageManager = (typeof supportedPackageManagers)[number];
@@ -26,10 +27,7 @@ export function detectPackageManager(directoryPath: string): PackageManager {
     return `npm`;
 }
 
-export function getInstallCommand(
-    packageManager: PackageManager,
-    debug: boolean = false,
-): string {
+export function getInstallCommand(packageManager: PackageManager): string {
     const installCommand = installCommands[packageManager];
     if (!installCommand) {
         const packageManagers = supportedPackageManagers.join(', ');
@@ -38,6 +36,6 @@ export function getInstallCommand(
         );
     }
 
-    const debugFlag = debug ? ` ${debugFlags[packageManager]}` : '';
+    const debugFlag = env.debug ? ` ${debugFlags[packageManager]}` : '';
     return `${installCommand}${debugFlag}`;
 }


### PR DESCRIPTION
This change allows us to see more detail when the package manager fails for whatever reason. For most package managers, the specific error message when not using `--verbose` (for example) only include a fairly generic error, even if the error is unrecoverable.