### PR TITLE
fix: add newlines around appended content, more logging for file manipulation and explicit checks for files and directories we rely on

### DIFF
--- a/lib/ssh.ts
+++ b/lib/ssh.ts
@@ -37,7 +37,7 @@ export async function setupSshCredentials(): Promise<void> {
         const configFile = `${sshDir}/config`;
         await fs.promises.appendFile(
             configFile,
-            `IdentityFile ${pipelinesIdFile}`
+            `\nIdentityFile ${pipelinesIdFile}\n`
         );
     } catch (e) {
         console.error(
@@ -51,7 +51,7 @@ export async function setupSshCredentials(): Promise<void> {
         console.log('Piping known hosts into runtime ssh config');
         const knownHosts = await fs.promises
             .readFile(knownHostsFile)
-            .then((buf) => buf.toString());
+            .then((buf) => `\n${buf.toString()}\n`);
         const hostsFile = `${sshDir}/known_hosts`;
         await fs.promises.appendFile(hostsFile, knownHosts);
     } catch (e) {


### PR DESCRIPTION
Largely to ensure we aren't introducing syntax errors when either file has content already
We also now check more explicitly for the files and directories we need.